### PR TITLE
Feature/uc8 search products

### DIFF
--- a/.github/workflows/maui-tests.yml
+++ b/.github/workflows/maui-tests.yml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet restore
 
       - name: Bouw de applicatie
-        run: dotnet build -f net8.0-android --configuration Release --no-restore
+        run: dotnet build -f net8.0 --configuration Release --no-restore
 
       - name: Voer unit tests uit
-        run: dotnet test -f net8.0-android --configuration Release --no-restore --no-build --verbosity normal
+        run: dotnet test -f net8.0 --configuration Release --no-restore --no-build --verbosity normal

--- a/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
+++ b/Grocery.App/ViewModels/GroceryListItemsViewModel.cs
@@ -86,5 +86,33 @@ namespace Grocery.App.ViewModels
             }
         }
 
+        [RelayCommand]
+        public void SearchProducts(string searchText)
+        {
+            // if the searchText is empty give the full list of available products
+            if (string.IsNullOrWhiteSpace(searchText))
+            {
+                GetAvailableProducts();
+            }
+            else
+            {
+                // Get the products if the product contains the searchText, casing is ingored
+                // Also checks if the items is not already in the groceryList and has more than 0 stock
+                IEnumerable<Product> filteredProducts = _productService.GetAll()
+                    .Where(p => p.Name.Contains(searchText, StringComparison.OrdinalIgnoreCase) 
+                                && MyGroceryListItems.FirstOrDefault(g => g.ProductId == p.Id) == null
+                                && p.Stock > 0);
+                
+                // Clear the Available products list
+                AvailableProducts.Clear();              
+                
+                // Fill the available products list with the items that come through the filter
+                foreach (Product product in filteredProducts)
+                {
+                    AvailableProducts.Add(product);
+                }
+            }
+        }
+        
     }
 }

--- a/Grocery.App/Views/GroceryListItemsView.xaml
+++ b/Grocery.App/Views/GroceryListItemsView.xaml
@@ -54,6 +54,7 @@
 
         <Border Grid.Row="1" Grid.Column="1" Stroke="#C49B33" StrokeThickness="4" Padding="5" Margin="5" HorizontalOptions="Center">
             <StackLayout>
+                <SearchBar Placeholder="Product zoeken" TextChanged="SearchCommand"></SearchBar>
                 <CollectionView ItemsSource="{Binding AvailableProducts}" Margin="5" WidthRequest="300" HorizontalOptions="Start"
                     SelectionMode="Single"
                     SelectionChangedCommand="{Binding AddProductCommand}"

--- a/Grocery.App/Views/GroceryListItemsView.xaml.cs
+++ b/Grocery.App/Views/GroceryListItemsView.xaml.cs
@@ -9,4 +9,9 @@ public partial class GroceryListItemsView : ContentPage
 		InitializeComponent();
         BindingContext = viewModel;
     }
+
+	private void SearchCommand(object sender, TextChangedEventArgs e)
+	{
+		((GroceryListItemsViewModel)BindingContext).SearchProducts(e.NewTextValue);
+	}
 }


### PR DESCRIPTION
# UC8 Search products
This branch adds the ability to search through the list of available products.

## Changes included
- SearchBar
  - Added a search bar to the avaible products panel.
  - The search bar listens for text changes and triggers `SearchCommand()` whenever the input is updated.
- `SearchCommand()`
  - Passed the updated search text to `SearchProducts()`
- `SearchProducts`
  - If the search bar is empty -> Show the full list of available products.
  - If search text is provided -> Show only the products that:
    - Contain the search text,
    - Are not already on the grocery list,
    - have a stock greater than zero.

## Summary
With this function you can search products to put in the grocery list.

## Fix
Removed android for building the application in the workflow.